### PR TITLE
feat: Re-enable caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Inspired by [nuxt/image](https://github.com/nuxt/image) and
 
 ## Demo
 
-A working demo is deployed at https://fresh-images.deno.dev.\
+A working demo is deployed at https://fresh-images.deno.dev.
+
 **([View source](https://github.com/jasonjgardner/fresh-images-demo))**
 
 ## Install
@@ -88,7 +89,7 @@ import { decode, type GIF, type Image } from "imagescript/mod.ts";
  * Rotate an image hue by a random number of degrees.
  * Optionally accept a query parameter to invert the hue.
  */
-const myTransformer = (img: Image | GIF, req: Request) => {
+const myTransformer = async (img: Image | GIF, req: Request) => {
   const randomDegrees = Math.floor(Math.random() * 360);
 
   // Use `extendKeyMap` to lookup custom parameters

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 Inspired by [nuxt/image](https://github.com/nuxt/image) and
 [next/image](https://nextjs.org/docs/app/building-your-application/optimizing/images).
 
+## Demo
+
+A working demo is deployed at https://fresh-images.deno.dev.\
+**([View source](https://github.com/jasonjgardner/fresh-images-demo))**
+
 ## Install
 
 Modify the import map in your Fresh project to include
@@ -23,7 +28,8 @@ Modify the import map in your Fresh project to include
 }
 ```
 
-Include the plugin and transformation functions in your `fresh.config.ts` file.
+Include the plugin and desired transformation functions in your
+`fresh.config.ts` file.
 
 ```ts
 import { defineConfig } from "$fresh/server.ts";
@@ -33,7 +39,7 @@ import { resize, rotate } from "fresh_images/transformer.ts";
 export default defineConfig({
   plugins: [
     ImagesPlugin({
-      route: "/img",
+      route: "/image",
       realPath: "./static/images",
       transformers: { resize, rotate },
     }),
@@ -41,14 +47,265 @@ export default defineConfig({
 });
 ```
 
+### Initializing the Plugin
+
+**`realPath`** — Defaults to `./static/image`. This is the static asset
+directory which contains images to transform.
+
+**`route`** — Defaults to `/images`. This property defines the alias URL to the
+image directory. Requests to this route are able to receive transformation
+function parameters to manipulate images in the `realPath` directory.
+
+> **Note:** `route` should not be the same name as a subdirectory in `./static`.
+
+**`tranformers`** — An object containing transformation functions, with the
+function name (`fn`) as keys and the image transformation function as the value.
+
+**`build`** — Optional function to pass to Fresh's `buildStart` hook. Useful for
+image preprocessing/pre-rendering.
+
+> **Note:** Build output must be saved in the `./static` directory in order to
+> be served. Use `.gitignore` to exclude the output directory if necessary.
+
+## Creating Transformations
+
+A transformer function accepts an instance of ImageScript's `Image` or `GIF`
+class to be modified according to the given URL parameters. It must also return
+the modified instance of `Image` or `GIF`.
+
+### [Example](https://github.com/jasonjgardner/fresh-images-demo/blob/091aa83bbbd45be4e6c5c798c58207aaeaf92dbe/fresh.config.ts#L17)
+
+```ts
+import ImagesPlugin, {
+  extendKeyMap,
+  getParam,
+  transform,
+} from "fresh_images/mod.ts";
+import { decode, type GIF, type Image } from "imagescript/mod.ts";
+
+/**
+ * Custom transformer example.
+ * Rotate an image hue by a random number of degrees.
+ * Optionally accept a query parameter to invert the hue.
+ */
+const myTransformer = (img: Image | GIF, req: Request) => {
+  const randomDegrees = Math.floor(Math.random() * 360);
+
+  // Use `extendKeyMap` to lookup custom parameters
+  const invert = getParam(req, "invert", extendKeyMap({ invert: "i" }));
+
+  // Use the `transform` helper function to apply asynchronous transformations.
+  // This ensures transformations will be applied to every frame of a GIF animation.
+  if (invert) {
+    img = await transform(img, (frame) => Promise.resolve((frame as Image).invertHue()));
+  }
+
+  return transform(
+    img,
+    (frame) => Promise.resolve((frame as Image).hueShift(randomDegrees)),
+  );
+};
+
+export default defineConfig({
+  plugins: [
+    ImagesPlugin({
+      transformers: {
+        cool: myTransformer,
+        withCustomRoute: {
+          // Always applies this `handler` transformation to the route.
+          // Uses same static image directory!
+          path: "/desaturate",
+          handler: (img: Image | GIF) =>
+            transform(
+              img,
+              (img) => Promise.resolve((img as Image).saturation(0, true)),
+            ),
+        },
+      },
+    }),
+});
+```
+
+[More examples](https://github.com/jasonjgardner/fresh-images-demo/tree/main/transformers)
+are available in the demo repository.
+
+#### Tip
+
+Pass multiple instances of the plugin to allow transformations in more than one
+image directory.
+
+```ts
+export default defineConfig({
+  plugins: [
+    // This creates a route, "/images", that will serve images from the "./static/image" directory.
+    ImagesPlugin(),
+    // Create a different route to access another directory.
+    ImagesPlugin({
+      route: "/placeholder",
+      realPath: "./static/placeholders",
+      transformers: {
+        // Only specified transformers will be available on this route.
+      },
+    }),
+  ],
+});
+```
+
+> **Note:** Nested directory routes are currently not supported.
+
 ## Usage
+
+Pass each transformation to apply as a `fn` parameter. Reference the
+[key map](./src/transformers/_keymap.ts) to view valid URL parameter keys.
+
+### URL Parameters
 
 Pass image transformation parameters in URL:
 
 ```html
 <!-- Rotate `./static/images/nyan.gif` 45 degrees and resize it to 500×600px -->
-<img src="/img/nyan.gif?fn=rotate&d=45&fn=resize&w=500&h=600" />
+<img src="/img/nyan.gif?fn=rotate&d=45&fn=resize&rw=500&rh=600" />
 ```
+
+### JSX Component
+
+Returns headless `div.fresh-image`. Contains `img.fresh-image__placeholder`
+and/or `img.fresh-image__image`.
+
+```jsx
+import FreshImage from "fresh_images/src/components/FreshImage.tsx";
+
+// Example using the `transformations` property
+<FreshImage
+  src="/image/meow.png"
+  alt="Cropped to 100px by 100px starting at 100px by 100px. Then resized to 200px by 200px."
+  transformations={[{
+    fn: "crop",
+    cropX: "100",
+    cropY: "100",
+    cropWidth: "100",
+    cropHeight: "100",
+  }, {
+    fn: "resize",
+    resizeWidth: "200",
+    resizeHeight: "200",
+  }]}
+/>
+
+// Define a `placeholder` image to display while the `src` image loads.
+<FreshImage
+  src="/image/cat.jpg"
+  placeholder="/placeholders/loading.png"
+  alt="Image with custom transformation and resize"
+  transformations={[{
+    fn: "cool",
+  }, {
+    fn: "resize",
+    rw: "400",
+  }]}
+/>
+
+// Set the `preload` property to inject `<link rel="preload">` for this image.
+// (Use wisely.)
+<FreshImage
+  src="/image/chonk.jpg"
+  alt="Big, hidden image"
+  preload="true"
+  transformations={{
+    fn: "resize",
+    resizeWidth: "1000",
+    quality: 100
+  }}
+/>
+```
+
+### Caching
+
+Deno Deploy
+[currently does not support the Cache API](https://docs.deno.com/deploy/api#future-support),
+but Deno KV can be utilized to serve cached images. Set the following
+environment variables to enable caching in Deno Deploy, but **use with
+caution**. Deno KV is not an ideal blob storage solution and comes with certain
+[costs and limitations](https://deno.com/deploy/pricing).
+
+#### Environment Variables
+
+- `USE_CACHE` – Enables image caching via
+  [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) (when
+  available) or Deno KV.
+- `USE_KV` — When `USE_CACHE` is `true`, setting this variable to `true` will
+  cache images using [kv_toolbox](https://deno.land/x/kv_toolbox@0.0.5)
+
+If `USE_CACHE=true` and `USE_KV=false`, caching will not be used on Deno Deploy.
+
+## Optional Build Step
+
+Although [caching is supported](#caching) for images rendered on-the-fly, it is
+always faster to load a pre-rendered, static asset when available.
+
+The Fresh images plugin runs the function provided in the `build` property
+during
+[ahead-of-time builds](https://fresh.deno.dev/docs/concepts/ahead-of-time-builds).
+This function receives the same arguments passed to the `ImagesPlugin` instance.
+
+```ts
+import type { ImagesPluginOptions } from "fresh_images/src/types.ts";
+import ImagesPlugin, { transform } from "fresh_images/mod.ts";
+import { ensureDir, join } from "$std/fs/mod.ts";
+import { defineConfig } from "$fresh/server.ts";
+import { decode, GIF, Image } from "imagescript/mod.ts";
+
+/**
+ * Pre-optimize images before serving them.
+ */
+const myBuildFunction: ImagesPluginOptions["build"] = async ({
+  realPath,
+}) => {
+  const targetDir = realPath ?? "./static";
+  const files = Deno.readDir("./static/image");
+
+  await ensureDir(targetDir);
+
+  // Resize all images in the directory
+  for await (const file of files) {
+    if (!file.isFile) {
+      continue;
+    }
+
+    const input = await Deno.readFile(`./static/image/${file.name}`);
+
+    const output = await transform(
+      await decode(input),
+      (img) => Promise.resolve((img as Image).resize(Image.RESIZE_AUTO, 100)),
+    );
+
+    // Encode at lowest quality
+
+    if (output instanceof GIF) {
+      await Deno.writeFile(
+        join(targetDir, file.name),
+        await output.encode(30),
+      );
+      continue;
+    }
+
+    await Deno.writeFile(
+      join(targetDir, file.name),
+      await output.encodeJPEG(1),
+    );
+  }
+};
+
+export default defineConfig({
+  plugins: [
+    ImagesPlugin({
+      build: myBuildFunction,
+    }),
+  ],
+});
+```
+
+[View full example](https://github.com/jasonjgardner/fresh-images-demo/blob/main/fresh.config.ts#L37)
 
 ## License
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,11 +1,5 @@
 import { Frame, GIF, Image } from "imagescript/mod.ts";
 import { KEYMAP } from "./transformers/_keymap.ts";
-// import { ASSET_CACHE_BUST_KEY } from "$fresh/runtime.ts";
-
-/**
- * Cache for transformed images
- */
-// export const CACHE = await caches.open(`fresh_images-${ASSET_CACHE_BUST_KEY}`);
 
 /**
  * Get a parameter from a URL or request.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,223 @@
+import { ASSET_CACHE_BUST_KEY } from "$fresh/runtime.ts";
+import { get, set } from "https://deno.land/x/kv_toolbox@0.0.5/blob.ts";
+
+export interface ICache {
+  init(): Promise<void>;
+  get(req: Request): Promise<Response | undefined>;
+  put(req: Request, res: Response): Promise<void>;
+  delete(req: Request): Promise<void>;
+}
+
+/**
+ * A cache interface that uses the Cache API as a backend.
+ * Currently not available on Deno Deploy.
+ */
+export class CacheStore implements ICache {
+  cache?: Cache;
+  constructor() {
+    if (!caches) {
+      throw new Error("Cache API not available");
+    }
+  }
+
+  async init() {
+    this.cache = await caches.open(`fresh-images-${ASSET_CACHE_BUST_KEY}`);
+  }
+
+  async get(req: Request) {
+    if (!this.cache) {
+      throw new Error("Cache API not available");
+    }
+
+    const cached = await this.cache.match(req);
+
+    if (cached) {
+      cached.headers.set("x-cache-hit", "true");
+      cached.headers.set("x-kv-hit", "false");
+      return cached;
+    }
+
+    return undefined;
+  }
+
+  async put(req: Request, res: Response) {
+    if (!this.cache) {
+      throw new Error("Cache API not available");
+    }
+
+    await this.cache.put(req, res.clone());
+  }
+
+  async delete(req: Request) {
+    if (!this.cache) {
+      throw new Error("Cache API not available");
+    }
+
+    await this.cache.delete(req);
+  }
+}
+
+/**
+ * A cache interface that uses the Deno KV as a backend.
+ * This is not ideal but is available on Deno Deploy.
+ */
+export class CacheKV implements ICache {
+  kv?: Deno.Kv;
+  constructor() {
+    if (!Deno.openKv) {
+      throw new Error("KV API not available");
+    }
+  }
+
+  /**
+   * Initialize the KV store.\
+   * Clear old cache entries in the process.
+   */
+  async init(): Promise<void> {
+    this.kv = await Deno.openKv();
+    try {
+      await this.clearOldCache();
+    } catch (err) {
+      console.error("Failed to clear old cache: %s", err);
+    }
+  }
+
+  async get(req: Request) {
+    if (!this.kv) {
+      throw new Error("KV API not available");
+    }
+
+    const data: Uint8Array | null = await get(this.kv, [
+      "data",
+      ASSET_CACHE_BUST_KEY,
+      req.url,
+    ]);
+
+    if (!data) {
+      return undefined;
+    }
+
+    const storedHeaders = await this.kv.get<Headers>([
+      "headers",
+      ASSET_CACHE_BUST_KEY,
+      req.url,
+    ]);
+    const headers = new Headers();
+
+    if (storedHeaders) {
+      for (const [key, value] of Object.entries(storedHeaders)) {
+        headers.set(key, value?.toString() ?? "");
+      }
+    }
+
+    if (!headers.has("content-type")) {
+      headers.set("content-type", "image/png");
+    }
+
+    headers.set("x-cache-hit", "true");
+    headers.set("x-kv-hit", "true");
+
+    return new Response(data, { headers });
+  }
+
+  async put(req: Request, res: Response) {
+    if (!this.kv) {
+      throw new Error("KV API not available");
+    }
+
+    const data = new Uint8Array(await res.arrayBuffer());
+    const entries = res.headers.entries();
+    const storedHeaders: Record<string, string> = {};
+
+    for (const [key, value] of entries) {
+      storedHeaders[key] = value;
+    }
+
+    await set(this.kv, ["data", ASSET_CACHE_BUST_KEY, req.url], data);
+    await this.kv.set(
+      ["headers", ASSET_CACHE_BUST_KEY, req.url],
+      storedHeaders,
+    );
+  }
+
+  async delete(req: Request) {
+    if (!this.kv) {
+      throw new Error("KV API not available");
+    }
+
+    await this.kv.delete(["data", ASSET_CACHE_BUST_KEY, req.url]);
+    await this.kv.delete(["headers", ASSET_CACHE_BUST_KEY, req.url]);
+  }
+
+  async clearOldCache() {
+    if (!this.kv) {
+      throw new Error("KV API not available");
+    }
+
+    const keys = await this.kv.get(["data"]);
+
+    if (!keys) {
+      return;
+    }
+
+    const ok = Object.keys(keys);
+    for (const key of ok) {
+      if (key === ASSET_CACHE_BUST_KEY) {
+        continue;
+      }
+
+      await this.kv.delete(["data", key]);
+      await this.kv.delete(["headers", key]);
+      console.log("Deleted old cache: %s", key);
+    }
+  }
+}
+
+/**
+ * A cache interface that does nothing.
+ */
+export class CacheNoop implements ICache {
+  constructor() {
+  }
+
+  async init() {
+  }
+
+  async get(_req: Request) {
+    return await Promise.resolve(undefined);
+  }
+
+  async put(_req: Request, _res: Response) {
+  }
+
+  async delete(_req: Request) {
+  }
+}
+
+/**
+ * Get available caching interface.
+ * @returns A cache interface determined by the environment.
+ */
+export async function getCache(): Promise<ICache> {
+  if (Deno.env.get("USE_CACHE") === "false") {
+    return new CacheNoop();
+  }
+
+  let cache: ICache | undefined = undefined;
+  let useKv = Deno.env.get("USE_KV") !== "false";
+
+  if (Deno.env.get("DENO_DEPLOYMENT_ID")) {
+    useKv = useKv !== false;
+  }
+
+  try {
+    cache = useKv ? new CacheKV() : new CacheStore();
+    await cache.init();
+
+    return cache;
+  } catch (err) {
+    console.error("Cache not available: %s", err);
+  }
+
+  return new CacheNoop();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -105,7 +105,7 @@ export class CacheKV implements ICache {
     const headers = new Headers();
 
     if (storedHeaders) {
-      for (const [key, value] of Object.entries(storedHeaders)) {
+      for (const [key, value] of Object.entries(storedHeaders.value ?? {})) {
         headers.set(key, value?.toString() ?? "");
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,5 +44,5 @@ export interface ImagesPluginOptions {
   /**
    * Ahead of time build function
    */
-  build?: () => Promise<void>;
+  build?: (props: Omit<ImagesPluginOptions, "build">) => Promise<void>;
 }


### PR DESCRIPTION
- Added workaround for Cache API on Deno Deploy. Utilizing KV as fallback cache.
- Passed plugin instance parameters to `build` function
- Updated README.md